### PR TITLE
Update NodeAccessor.ts

### DIFF
--- a/src/node/NodeAccessor.ts
+++ b/src/node/NodeAccessor.ts
@@ -40,7 +40,7 @@ export class NodeAccessor extends AbstractAccessor {
     try {
       statSync(rootDir);
     } catch {
-      mkdirSync(rootDir);
+      mkdirSync(rootDir, { recursive: true });
     }
     this.filesystem = new NodeFileSystem(this);
     this.name = rootDir;


### PR DESCRIPTION
It's possible to have exception in catch block when parent path doesn't exist as well.
I believe you meant to create path recursively.
But note that even with `recursive: true` an exception is possible:
```
touch /path/to/file
mkdir /path/to/file/nested/segments
```